### PR TITLE
A better error msg when gpg key is valid & check if key is armored before uploading

### DIFF
--- a/pkg/cmd/gpg-key/add/http.go
+++ b/pkg/cmd/gpg-key/add/http.go
@@ -49,6 +49,9 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) e
 		if errors.As(err, &httpError) && isDuplicateError(&httpError) {
 			return nil
 		}
+		if errors.As(err, &httpError) && isKeyInvalidError(&httpError) {
+			return errors.New("invalid GPG key")
+		}
 		return err
 	}
 
@@ -63,4 +66,9 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) e
 func isDuplicateError(err *api.HTTPError) bool {
 	return err.StatusCode == 422 && len(err.Errors) == 2 &&
 		err.Errors[0].Field == "key_id" && err.Errors[0].Message == "key_id already exists"
+}
+
+func isKeyInvalidError(err *api.HTTPError) bool {
+	return err.StatusCode == 422 && len(err.Errors) == 1 &&
+		err.Errors[0].Field == "" && err.Errors[0].Message == "We got an error doing that."
 }

--- a/pkg/cmd/gpg-key/add/http.go
+++ b/pkg/cmd/gpg-key/add/http.go
@@ -61,6 +61,6 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) e
 }
 
 func isDuplicateError(err *api.HTTPError) bool {
-	return err.StatusCode == 422 && len(err.Errors) == 1 &&
-		err.Errors[0].Field == "key" && err.Errors[0].Message == "key is already in use"
+	return err.StatusCode == 422 && len(err.Errors) == 2 &&
+		err.Errors[0].Field == "key_id" && err.Errors[0].Message == "key_id already exists"
 }


### PR DESCRIPTION


The go community has marked `x/crypto/openpgp` as frozen&deprecated,  I guess it's not a good idea to import that package or implement a armor algorithm, which will be a maintenance burden. So a better error message is perfered.

When the gpg key is invalid(not armored or armored but not in correct format), Github will give a response like:

```json
{
	"message": "Validation Failed",
	"errors": [{
		"resource": "GpgKey",
		"code": "custom",
		"message": "We got an error doing that."
	}],
	"documentation_url": "https://docs.github.com/v3/users/gpg_keys"
}
```

I added a function `isKeyInvalidError()`  handle this error response.

Besides, I added a function `isGpgKeyArmored()` to judge if a gpg key is armored before uploading . Technically it's just checking if file is started with`-----BEGIN PGP PUBLIC KEY BLOCK-----`,  but this is enough to make sure the input file is a armored gpg key. Afetr all, this function is to tell if a key is armored, not validated.